### PR TITLE
Direct call to constructor removed.

### DIFF
--- a/QRCode-OpenCV/qrCodeOpencv.cpp
+++ b/QRCode-OpenCV/qrCodeOpencv.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
   else
     inputImage = imread("qrcode-learnopencv.jpg");
 
-  QRCodeDetector qrDecoder = QRCodeDetector::QRCodeDetector();
+  QRCodeDetector qrDecoder;
 
   Mat bbox, rectifiedImage;
 


### PR DESCRIPTION
Resolved error: cannot call constructor ‘cv::QRCodeDetector::QRCodeDetector’ directly [-fpermissive]