### PR TITLE
Specify OpenCV_DIR in cmake command

### DIFF
--- a/QRCode-OpenCV/CMakeLists.txt
+++ b/QRCode-OpenCV/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 2.8.12)
 
 PROJECT(opencv_tests)
 
-set(OpenCV_DIR <specify your path to the opencv installation directory>installations/OpenCV4/lib/cmake/opencv4/)
+if(NOT OpenCV_DIR)
+  set(OpenCV_DIR <specify your path to the opencv installation directory>installations/OpenCV4/lib/cmake/opencv4/)
+endif()
 find_package( OpenCV REQUIRED )
 
 set(CMAKE_CXX_STANDARD 11)

--- a/QRCode-OpenCV/README.md
+++ b/QRCode-OpenCV/README.md
@@ -6,7 +6,15 @@ This directory contains code for using OpenCV QR code. This code requires **Open
 # For C++
 
 ## How to compile the code
-First Specify the **OpenCV_DIR** in CMakeLists.txt file. Then,
+
+Specify the **OpenCV_DIR** in CMake option
+
+```
+cmake -D OpenCV_DIR=<path to opencv install directory>/lib/cmake/opencv4/ .
+make
+```
+
+OR First Specify the **OpenCV_DIR** in CMakeLists.txt file. Then,
 
 ```
 cmake .


### PR DESCRIPTION
Specify OpenCV_DIR in cmake command without editing CMakefile.txt. eg. cmake -D OpenCV_DIR=<path to OpenCV installation dir>/lib/cmake/opencv4/ .